### PR TITLE
Remove unused and misleading shebang line

### DIFF
--- a/V.pm
+++ b/V.pm
@@ -1,5 +1,3 @@
-#!/pro/bin/perl
-
 package Config::Perl::V;
 
 use strict;


### PR DESCRIPTION
This is a minor irritation for Debian because it triggers a sanity check that the perl interpreter path location is correct. Since the file is not intended to be run as a script, the shebang line doesn't make sense 