### PR TITLE
Config-Perl-V: skip md5 tests on non-ASCII

### DIFF
--- a/t/20_plv56.t
+++ b/t/20_plv56.t
@@ -39,7 +39,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "9dc187182be100c1713f210a8c6d9f45";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 __END__
 Summary of my perl5 (revision 5.0 version 6 subversion 2) configuration:

--- a/t/21_plv58.t
+++ b/t/21_plv58.t
@@ -42,7 +42,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "df48dce1adaaf63855d8acd455c51818";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 __END__
 Summary of my perl5 (revision 5 version 8 subversion 9) configuration:

--- a/t/22_plv510.t
+++ b/t/22_plv510.t
@@ -32,7 +32,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "ce0a7871dfddbbed0a6c685c0f52dbf9";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 __END__
 Summary of my perl5 (revision 5 version 10 subversion 0) configuration:

--- a/t/23_plv512.t
+++ b/t/23_plv512.t
@@ -42,7 +42,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "a2c38153cc47d340bc140d0bfe294afb";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 __END__
 Summary of my perl5 (revision 5 version 12 subversion 2) configuration:

--- a/t/24_plv514.t
+++ b/t/24_plv514.t
@@ -43,7 +43,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "778815a670c0c454738aedf0c88930ba";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 __END__
 Summary of my perl5 (revision 5 version 14 subversion 2) configuration:

--- a/t/25_plv516.t
+++ b/t/25_plv516.t
@@ -43,7 +43,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "7b00cf3b306d96fa802892e6ad4b070f";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 __END__
 Summary of my perl5 (revision 5 version 16 subversion 3) configuration:

--- a/t/25_plv5162.t
+++ b/t/25_plv5162.t
@@ -45,7 +45,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "2917ca2a97b6db1ab8fb08798f53c0bb";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [
     "/Library/Perl/Updates/<version> comes before system perl directories",

--- a/t/26_plv518.t
+++ b/t/26_plv518.t
@@ -43,7 +43,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "8f46b07a7775e6a92347d4cd564b8f03";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/26_plv5182.t
+++ b/t/26_plv5182.t
@@ -43,7 +43,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "874325856acfea3dab7e7c944660f398";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/27_plv5200.t
+++ b/t/27_plv5200.t
@@ -46,7 +46,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "3e7b4513cd80c6ef00fcd77e5e16f8b4";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/27_plv5202.t
+++ b/t/27_plv5202.t
@@ -46,7 +46,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "9f954ebc2be7b1d7e151ab28dbdf7062";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/28_plv5220.t
+++ b/t/28_plv5220.t
@@ -46,7 +46,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "ddcc2d51e43bf18f5234ba66529068ef";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/28_plv52201w.t
+++ b/t/28_plv52201w.t
@@ -46,7 +46,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "dfb32b8299b66e8bdb2712934f700d94";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/29_plv5235w.t
+++ b/t/29_plv5235w.t
@@ -46,7 +46,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "bccd5d78dfebd48b89faf7f1fe711733";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/30_plv5240.t
+++ b/t/30_plv5240.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "3dffae79f6d2c74073f0d64646709101";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/31_plv52511.t
+++ b/t/31_plv52511.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "f0e463400e40ca35b67cec3834b5b9b7";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches},
     [ "SMOKEaa9ac6cf00899a6f55881d4ca6c1214215dc83ee" ], "Local patches");

--- a/t/32_plv5261rc1.t
+++ b/t/32_plv5261rc1.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "dd710670fec7d2e260414648dcc94e89";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ "RC1" ], "No local patches");
 

--- a/t/33_plv52711r.t
+++ b/t/33_plv52711r.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "bd9cf7a142ddbb434adea5b08eaefdc8";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "Local patches");
 

--- a/t/34_plv5280.t
+++ b/t/34_plv5280.t
@@ -43,7 +43,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "4add7fd04b60c2048a46ff47087e6952";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [], "No local patches");
 

--- a/t/35_plv52910g.t
+++ b/t/35_plv52910g.t
@@ -43,7 +43,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "8404b533829bd9752df7f662a710f993";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [
     "SMOKEdfba4714a9dc4c35123b4df0a5e1721ccb081d97" ], "No local patches");

--- a/t/36_plv5300.t
+++ b/t/36_plv5300.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "b1138522685da4fff74f7b1118128d02";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ ], "No patches");
 

--- a/t/37_plv53111qm.t
+++ b/t/37_plv53111qm.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "146e648c6239f623b8a8242fc8b5759f";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ ], "No patches");
 

--- a/t/38_plv5320tld.t
+++ b/t/38_plv5320tld.t
@@ -44,7 +44,11 @@ foreach my $o (sort keys %$opt) {
 eval { require Digest::MD5; };
 my $md5 = $@ ? "0" x 32 : "901df8463a7bda6075bd75539214e75e";
 ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+
+SKIP: {
+    skip "ASCII-centric test", 1 if ord "A" != 65;
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ ], "No patches");
 


### PR DESCRIPTION
This commit causes this module to run on an EBCDIC platform without its tests generating errors or warnings.

There are no code changes required!

What is done is to skip each test that is looking for a particular checksum value.  These values will necessarily be different on a platform with a different character set.  Another option would be to calculate the values on the box we have access to, but that would require more maintenance as new items are added, and should we ever start testing Perl on a machine with a different flavor of EBCDIC, that would generate a different checksum, and things would fail.  

I think the fact that the tests otherwise work on EBCDIC platforms is good enough