### PR TITLE
Makefile.PL: Add INSTALLDIRS key-value pair

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ my %wm = (
     AUTHOR        =>   "H.Merijn Brand <h.m.brand\@xs4all.nl>",
     VERSION_FROM  =>   "V.pm",
     ABSTRACT_FROM =>   "V.pm",
+    INSTALLDIRS => ($] < 5.011 ? 'perl' : 'site'),
 
     PREREQ_PM	  => { "Config"	=> 0,				},
     macro         => { TARFLAGS => "--format=ustar -c -v -f",	},


### PR DESCRIPTION
In the course of working on https://github.com/Perl/perl5/issues/12722, it became evident that the CPAN version of Config-Perl-V's `Makefile.PL` does not set an `INSTALLDIRS` key-value pair.  That raises the possibility that if someone were to install the library against a pre-5.12 perl, it would be installed in the wrong location.

This pull request adds an `INSTALLDIRS` key-value pair per the recommendation in
https://github.com/Perl/perl5/issues/12722#issuecomment-544040160. Please review.