### PR TITLE
Config-Perl-V: Skip ASCII centric tests

### DIFF
--- a/t/39_plv5340tqm.t
+++ b/t/39_plv5340tqm.t
@@ -35,15 +35,18 @@ foreach my $o (sort qw(
 	)) {
     is ($conf->{build}{options}{$o}, 1, "Runtime option $o set");
     delete $opt->{$o};
-    }
+}
 foreach my $o (sort keys %$opt) {
     is ($conf->{build}{options}{$o}, 0, "Runtime option $o unset");
-    }
+}
 
-eval { require Digest::MD5; };
-my $md5 = $@ ? "0" x 32 : "12cfb15586bf005d29ff4c7ce770aefe";
-ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+SKIP: {
+    skip "ASCII-centric test", 2 unless ord "A" == 65;
+    eval { require Digest::MD5; };
+    my $md5 = $@ ? "0" x 32 : "12cfb15586bf005d29ff4c7ce770aefe";
+    ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ ], "No patches");
 

--- a/t/40_plv5358dnqm.t
+++ b/t/40_plv5358dnqm.t
@@ -39,10 +39,13 @@ foreach my $o (sort keys %$opt) {
     is ($conf->{build}{options}{$o}, 0, "Runtime option $o unset");
     }
 
-eval { require Digest::MD5; };
-my $md5 = $@ ? "0" x 32 : "3a52d65d54ee1032f878b51fb20c8efd";
-ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+SKIP: {
+    skip "ASCII-centric test", 2 unless ord "A" == 65;
+    eval { require Digest::MD5; };
+    my $md5 = $@ ? "0" x 32 : "3a52d65d54ee1032f878b51fb20c8efd";
+    ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ ], "No patches");
 

--- a/t/41_plv5360dnqm.t
+++ b/t/41_plv5360dnqm.t
@@ -40,10 +40,13 @@ foreach my $o (sort keys %$opt) {
     is ($conf->{build}{options}{$o}, 0, "Runtime option $o unset");
     }
 
-eval { require Digest::MD5; };
-my $md5 = $@ ? "0" x 32 : "e8348134908b3d371c277aff6da654b8";
-ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
-is ($sig, $md5, "MD5");
+SKIP: {
+    skip "ASCII-centric test", 2 unless ord "A" == 65;
+    eval { require Digest::MD5; };
+    my $md5 = $@ ? "0" x 32 : "e8348134908b3d371c277aff6da654b8";
+    ok (my $sig = Config::Perl::V::signature ($conf), "Get signature");
+    is ($sig, $md5, "MD5");
+}
 
 is_deeply ($conf->{build}{patches}, [ ], "No patches");
 


### PR DESCRIPTION
This is a follow-on to #3   With these changes, this module passes on EBCDIC boxes